### PR TITLE
Improved precommit hook by moving logic into git

### DIFF
--- a/bin/precommit-hook.sh
+++ b/bin/precommit-hook.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+GIT_DIR=$(dirname ${DIR})
+
+# Checks for changed Javascript, and runs ESLint if required
+CHANGED_FILES=$(git diff --name-only --cached --relative | grep '\.jsx\?$')
+if [ $? -eq 0 ]; then
+    echo Running ESLint...
+    echo $CHANGED_FILES | xargs $GIT_DIR/node_modules/.bin/eslint
+    if [ $? -ne 0 ]; then
+        echo 'ESLint failed, aborting commit.'
+        exit 1;
+    else
+        echo 'Good to go!'
+    fi
+fi

--- a/src/build/install-precommit.js
+++ b/src/build/install-precommit.js
@@ -15,25 +15,14 @@ module.exports = function (winston) {
 
   let commandLines = [
     beforeLine,
-    '# Disable this by removing the lines below. Leave the above line intact,',
-    '# as the file checker looks for this.',
-    'git diff --name-only --cached --relative \\',
-    '  | grep \'\\.jsx\\?$\' \\',
-    `  | xargs ${root}/node_modules/.bin/eslint`,
-    'if [ $? -ne 0 ];',
-    'then',
-    '  exit 1;',
-    'fi',
+    `${root}/bin/precommit-hook.sh`,
     afterLine
   ]
 
   if (!exists(precommitFile)) {
     winston.debug(`Creating file with basic content at ${precommitFile}...`)
     try {
-      let content = [
-        '#!/usr/bin/env bash',
-        'set -xe'
-      ].join('\n')
+      let content = '#!/usr/bin/env bash\n'
 
       fs.writeFileSync(precommitFile, content, {
         mode: 0o775


### PR DESCRIPTION
Remove your .git/hooks/pre-commit file, the script will re-create it
automatically.

This way we can add pre-commit checks easily