### PR TITLE
Fixed UUIDs not being available on PowerUp and Account models

### DIFF
--- a/database/migration/20170324114819-powerup-uuids.js
+++ b/database/migration/20170324114819-powerup-uuids.js
@@ -1,0 +1,30 @@
+/**
+  * Adds UUIDs to powerup table
+  *
+  * @author Roelof Roos <github@roelof.io>
+ */
+module.exports = {
+  up: function (queryInterface, Sequelize) {
+    return queryInterface.changeColumn(
+      'powerUps',
+      'id',
+      {
+        type: Sequelize.UUID,
+        allowNull: false,
+        autoIncrement: false
+      }
+    )
+  },
+
+  down: function (queryInterface, Sequelize) {
+    return queryInterface.changeColumn(
+      'powerUps',
+      'id',
+      {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        autoIncrement: true
+      }
+    )
+  }
+}

--- a/database/migration/20170324155212-account-uuids.js
+++ b/database/migration/20170324155212-account-uuids.js
@@ -1,0 +1,30 @@
+/**
+  * Adds UUIDs to account table
+  *
+  * @author Roelof Roos <github@roelof.io>
+ */
+module.exports = {
+  up: function (queryInterface, Sequelize) {
+    return queryInterface.changeColumn(
+      'accounts',
+      'id',
+      {
+        type: Sequelize.UUID,
+        allowNull: false,
+        autoIncrement: false
+      }
+    )
+  },
+
+  down: function (queryInterface, Sequelize) {
+    return queryInterface.changeColumn(
+      'accounts',
+      'id',
+      {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        autoIncrement: true
+      }
+    )
+  }
+}

--- a/database/seed/20170322140122-power-up.js
+++ b/database/seed/20170322140122-power-up.js
@@ -2,26 +2,43 @@
  * Seeds the power-up table with the most amazing power-ups
  *
  * @author Remco Schipper <github@remcoschipper.com>
+ * @author Roelof Roos <github@roelof.io>
  */
+
+let uuids = [
+  '543fbfb8-f3cf-4104-b655-95c1d59e8836',
+  '8d4aa374-a667-406a-8e06-06be0273528a',
+  'bf7e56fa-004c-4de5-8d73-9062f508b829',
+  '370f0b4e-fa8c-411b-abc2-831ecdb66660'
+]
 
 module.exports = {
   up: function (queryInterface, Sequelize) {
     return queryInterface.bulkInsert('powerUps', [{
+      id: uuids.shift(),
       name: 'Nuclear rocket',
       persistent: true
     }, {
+      id: uuids.shift(),
       name: 'Kim\'s dogs',
       persistent: false
     }, {
+      id: uuids.shift(),
       name: 'North Korean food',
       persistent: true
     }, {
+      id: uuids.shift(),
       name: 'Iranian plague',
       persistent: false
     }], {})
   },
 
   down: function (queryInterface, Sequelize) {
-    return queryInterface.bulkDelete('powerUps', null, {})
+    let rows = []
+    uuids.forEach(function (uuid) {
+      rows.push({id: uuid})
+    })
+
+    return queryInterface.bulkDelete('powerUps', rows, {})
   }
 }

--- a/database/seed/20170324155222-account.js
+++ b/database/seed/20170324155222-account.js
@@ -5,9 +5,15 @@
  */
 const bcrypt = require('bcrypt')
 
+let uuids = [
+  '3345f5c2-4106-4c62-ba27-a826f35d2a37',
+  '78e1b61b-59b9-457d-aa45-d6b4fac96ee5'
+]
+
 module.exports = {
   up: function (queryInterface, Sequelize) {
     return queryInterface.bulkInsert('accounts', [{
+      id: uuids.shift(),
       name: 'Brian',
       email: 'brian-the-second@king.com',
       password: bcrypt.hashSync('supreme-leader', 10),
@@ -16,6 +22,7 @@ module.exports = {
       experiencePoints: 2147483647,
       preferredTeam: 'red'
     }, {
+      id: uuids.shift(),
       name: 'Kim Jong-Un',
       email: 'kim@north-korea',
       password: bcrypt.hashSync('brian', 10),
@@ -27,6 +34,10 @@ module.exports = {
   },
 
   down: function (queryInterface, Sequelize) {
-    return queryInterface.bulkDelete('accounts', null, {})
+    var rows = []
+    uuids.forEach(function (id) {
+      rows.push({id: id})
+    })
+    return queryInterface.bulkDelete('accounts', rows, {})
   }
 }

--- a/src/model/power-up.js
+++ b/src/model/power-up.js
@@ -6,6 +6,15 @@
 
 module.exports = function (sequelize, DataTypes) {
   return sequelize.define('powerUp', {
+    id: {
+      type: DataTypes.UUID,
+      defaultValue: DataTypes.UUIDV4,
+      primaryKey: true,
+      validate: {
+        notEmpty: true,
+        isUUID: 4
+      }
+    },
     name: {
       type: DataTypes.STRING(64),
       allowNull: false


### PR DESCRIPTION
Fixes UUIDs instead of integer indexes on the `Account` and `PowerUp` model.

Flush out your seeds before seeding!

```sql
DELETE FROM powerUps
WHERE powerUps.name IN (
    'Nuclear rocket'
    'Kim\'s dogs'
    'North Korean food'
    'Iranian plague'
);

DELETE FROM accounts
WHERE (
    accounts.name = 'Brian' AND
    accounts.email = 'brian-the-second@king.com' AND
    accounts.coins = 2147483647 AND
    accounts.token IS NULL AND
    accounts.experiencePoints = 2147483647 AND
    accounts.preferredTeam = 'red'
) OR (
    accounts.name = 'Kim Jong-Un' AND
    accounts.email = 'kim@north-korea' AND
    accounts.coins = 1 AND
    accounts.token IS NULL AND
    accounts.experiencePoints = 1 AND
    accounts.preferredTeam = 'black'
);
```